### PR TITLE
[Add] spec.add_runtime_dependency http

### DIFF
--- a/fbase_auth.gemspec
+++ b/fbase_auth.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "http"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION

Hi,
it seems http is necessary to add to dependency.
(I got error when loading Rails app
'config/application.rb'
)

Thank you for nice gem. :)